### PR TITLE
Update readme to include construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 ```js
 sudo pip install git+git://github.com/nasa8x/mixhash.git
 
+sudo pip install construct==2.5.2
+
 git clone https://github.com/nasa8x/genesis-block.git
 
 cd genesis-block


### PR DESCRIPTION
Without the construct module installed, the script cannot run. Furthermore, this script only seems to work with construct 2.5.2 as far as I know.